### PR TITLE
updating environmental crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1501,9 +1501,9 @@ dependencies = [
 
 [[package]]
 name = "environmental"
-version = "1.1.2"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6576a1755ddffd988788025e75bce9e74b018f7cc226198fe931d077911c6d7e"
+checksum = "68b91989ae21441195d7d9b9993a2f9295c7e1a8c96255d8b729accddc124797"
 
 [[package]]
 name = "erased-serde"

--- a/primitives/externalities/Cargo.toml
+++ b/primitives/externalities/Cargo.toml
@@ -16,7 +16,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 sp-storage = { version = "3.0.0", path = "../storage", default-features = false }
 sp-std = { version = "3.0.0", path = "../std", default-features = false }
-environmental = { version = "1.1.2", default-features = false }
+environmental = { version = "1.1.3", default-features = false }
 codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false }
 
 [features]


### PR DESCRIPTION
This tiny PR updates the `environmental` crate from 1.1.2 to 1.1.3 due to the use of the `const_fn` feature.