### PR TITLE
Small cargo check fix

### DIFF
--- a/bin/node/executor/benches/bench.rs
+++ b/bin/node/executor/benches/bench.rs
@@ -49,6 +49,8 @@ const SPEC_VERSION: u32 = node_runtime::VERSION.spec_version;
 
 const HEAP_PAGES: u64 = 20;
 
+const NET: u128 = 1000;
+
 type TestExternalities<H> = CoreTestExternalities<H, u64>;
 
 #[derive(Debug)]
@@ -153,7 +155,7 @@ fn test_blocks(genesis_config: &GenesisConfig, executor: &NativeExecutor<Executo
 	block1_extrinsics.extend((0..20).map(|i| {
 		CheckedExtrinsic {
 			signed: Some((alice(), signed_extra(i, 0))),
-			function: Call::Balances(pallet_balances::Call::transfer(bob().into(), 1 * DOLLARS)),
+			function: Call::Balances(pallet_balances::Call::transfer(bob().into(), 1 * NET)),
 		}
 	}));
 	let block1 = construct_block(


### PR DESCRIPTION
This PR adds  the `const NET: u128 = 1000;` to `bin/node/executor/benches/bench.rs` to prevent a `cargo check` error