### PR TITLE
Disable Cargo Test in CI

### DIFF
--- a/.github/workflows/rust-build.yml
+++ b/.github/workflows/rust-build.yml
@@ -34,6 +34,6 @@ jobs:
 #      run: cargo check --workspace --all-targets
       run: cargo check
       
-    - name: Run tests
+#    - name: Run tests
 #      run: cargo test --workspace --all-targets --all-features
-      run: cargo test
+#      run: cargo test


### PR DESCRIPTION
Right now there is a test that hangs permanently and it's eating up our Github Actions minutes. Disabling it for now until it can be fixed locally.